### PR TITLE
fix(frontend): header and course list mobile tm-61

### DIFF
--- a/apps/frontend/src/libs/components/courses/styles.module.css
+++ b/apps/frontend/src/libs/components/courses/styles.module.css
@@ -13,19 +13,13 @@
 	}
 }
 
-@media screen and (width <= 1024px) {
-	.list {
-		grid-template-columns: repeat(3, 1fr);
-	}
-}
-
-@media screen and (width <= 768px) {
+@media screen and (width <= 865px) {
 	.list {
 		grid-template-columns: repeat(2, 1fr);
 	}
 }
 
-@media screen and (width <= 480px) {
+@media screen and (width <= 590px) {
 	.list {
 		grid-template-columns: 1fr;
 	}

--- a/apps/frontend/src/libs/components/header/styles.module.css
+++ b/apps/frontend/src/libs/components/header/styles.module.css
@@ -17,10 +17,10 @@
 
 @media screen and (width <= 480px) {
 	.header {
-		width: calc(100% - 50px);
+		width: calc(100% - 40px);
 		max-height: 55px;
 		padding: 5px;
-		margin: 10px 25px 0;
+		margin: 10px 20px 0;
 		border-radius: 13px;
 	}
 

--- a/apps/frontend/src/pages/overview/styles.module.css
+++ b/apps/frontend/src/pages/overview/styles.module.css
@@ -12,12 +12,19 @@
 }
 
 .courses-title {
+	margin: 0 0 10px;
 	font-size: var(--font-size-400);
 }
 
 @media screen and (width <= 1024px) {
 	.container {
 		padding: 15px 20px;
+	}
+}
+
+@media screen and (width <= 480px) {
+	.courses-title {
+		font-size: var(--font-size-300);
 	}
 }
 


### PR DESCRIPTION
We had to change the fixed breakpoints of 769px and 480px to 865px and 590px for the course list because the layout was breaking in between (the content of the buttons in the modal window and the really small size of the cards on the homepage).
![course-home](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/cf7057cf-b979-4c79-a055-bf08e2a4046d)

Header:
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/0adcd33c-8d97-4c3c-a317-825c18fe051b)

Nothing will break in the modal either:
![course-modal](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/48548964-67bb-4ba0-8a71-191062a7568a)
