### PR TITLE
fix(frontend): background color for auth on autofill tm-233

### DIFF
--- a/apps/frontend/src/libs/components/input/styles.module.css
+++ b/apps/frontend/src/libs/components/input/styles.module.css
@@ -46,12 +46,6 @@
 	transition: background-color 1s 5000s;
 }
 
-.input:-webkit-autofill,
-.input:-webkit-autofill:hover,
-.input:-webkit-autofill:focus {
-	box-shadow: 0 0 0 1000px var(--color-background) inset;
-}
-
 .light {
 	color: var(--color-text-200);
 	background-color: var(--color-background);
@@ -64,6 +58,12 @@
 
 .light:valid {
 	color: var(--color-text-300);
+}
+
+.light:-webkit-autofill,
+.light:-webkit-autofill:hover,
+.light:-webkit-autofill:focus {
+	box-shadow: 0 0 0 1000px var(--color-background) inset;
 }
 
 .error {

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,7 @@
 		},
 		"apps/frontend": {
 			"name": "@trackmates/frontend",
-			"version": "1.8.0",
+			"version": "1.9.2",
 			"dependencies": {
 				"@hookform/resolvers": "3.3.4",
 				"@reduxjs/toolkit": "2.0.1",


### PR DESCRIPTION
The background color of the field remains green (#037768):
![autifill-login](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/35ad1cc2-baab-4ca6-9818-295f4e29098f)
![autifill-reg](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/b7872a5d-bf98-47b3-8c7b-e76f826a91b7)

Nothing has changed for the other inputs. 
![autifill-search](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/c38eb6e1-6dfb-4e88-802a-85137aad826f)
![autifill-profile](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/bfed6f2d-0d79-4870-ae1c-f0b479278f4b)
![autifill-modal](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/f2babfda-8e27-4028-b5b9-ae0af4c05a61)
