### PR TITLE
fix(frontend): The "YouTube" character is overlaid on extralong names at certain screen widths tm-330

### DIFF
--- a/apps/frontend/src/pages/overview/libs/components/welcome-section-header/styles.module.css
+++ b/apps/frontend/src/pages/overview/libs/components/welcome-section-header/styles.module.css
@@ -79,7 +79,7 @@
 
 @media screen and (width <= 1400px) {
 	.welcome-section-header-content {
-		max-width: 450px;
+		max-width: 40%;
 	}
 
 	.welcome-section-header-subtitle {
@@ -110,6 +110,10 @@
 		padding: 8px 15px;
 		font-size: var(--font-size-200);
 	}
+
+	.particle {
+		display: none;
+	}
 }
 
 @media screen and (width <= 836px) {
@@ -123,10 +127,6 @@
 
 	.welcome-section-header-subtitle {
 		font-size: var(--font-size-400);
-	}
-
-	.welcome-section-header-content {
-		max-width: 250px;
 	}
 
 	.add-course-button {
@@ -162,7 +162,7 @@
 
 @media screen and (width <= 600px) {
 	.welcome-section-header-content {
-		max-width: 170px;
+		max-width: 150px;
 	}
 
 	.welcome-section-header-subtitle {


### PR DESCRIPTION
Before
![Screenshot_3](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/91093431/a5d81897-8ad3-4da6-8600-b4ec5c209dfe)

After
![Screenshot_2](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/91093431/28e1ea08-da5c-430e-b8ba-3b88cb9d9dbe)
