### PR TITLE
fix(frontend): added course should be rendered only on the last page tm-399

### DIFF
--- a/apps/frontend/src/modules/user-courses/slices/user-courses.slice.ts
+++ b/apps/frontend/src/modules/user-courses/slices/user-courses.slice.ts
@@ -22,8 +22,8 @@ const initialState: State = {
 
 const { actions, name, reducer } = createSlice({
 	extraReducers(builder) {
-		builder.addCase(add.fulfilled, (state, action) => {
-			state.myCourses = [...state.myCourses, action.payload];
+		builder.addCase(add.fulfilled, (state) => {
+			state.totalMyCoursesCount++;
 			state.dataStatus = DataStatus.FULFILLED;
 		});
 		builder.addCase(add.pending, (state) => {

--- a/apps/frontend/src/pages/overview/overview.tsx
+++ b/apps/frontend/src/pages/overview/overview.tsx
@@ -52,7 +52,7 @@ const Overview: React.FC = () => {
 				userId: user.id,
 			}),
 		);
-	}, [dispatch, user, page]);
+	}, [dispatch, user, page, totalCount]);
 
 	return (
 		<div className={styles["container"]}>


### PR DESCRIPTION
The images below show the behavior of the course list in different situations.

- There are 10 courses on the page, we don't render a new course on it.
![pagination-bug-one](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/497c2bde-ce40-4ad7-badc-091a8d67fa94)

- The last page is open, there is enough space for a new course, it appears on the page after adding it.
![pagination-bug-two](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/dbda8759-5a9a-4975-8f25-fc41607aacd0)

- The last page is open, but there are already 10 courses on it. The page count will increase and the new course will be on the next page.
![pagination-bug-three](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/0c1fe6a2-9686-42f8-bc39-c9a8ffea98f1)
