### PR TITLE
fix(backend): fix pagination on the "Find friends"  tab tm-454

### DIFF
--- a/apps/backend/src/modules/friends/friend.repository.ts
+++ b/apps/backend/src/modules/friends/friend.repository.ts
@@ -265,7 +265,13 @@ class FriendRepository implements Repository<UserEntity> {
 					.where(`${DatabaseTableName.FRIENDS}.follower_id`, "=", id)
 					.whereNotNull(`${DatabaseTableName.FRIENDS}.follower_id`),
 			)
-			.distinct()
+			.groupBy(
+				`${DatabaseTableName.USERS}.id`,
+				"userDetails.id",
+				"userDetails:avatar_file.id",
+				"groups.id",
+				"groups:permissions.id",
+			)
 			.withGraphJoined(
 				`[${RelationName.USER_DETAILS}.${RelationName.AVATAR_FILE}, ${RelationName.GROUPS}.${RelationName.PERMISSIONS}]`,
 			)


### PR DESCRIPTION
Fixed pagination on the "Find friends" tab to work correctly, when the users, featured on the tab, follow each other