### PR TITLE
fix(frontend): Selected chat remains activated after clicking "Back" button on the "Chats" page tm-514

### DIFF
--- a/apps/frontend/src/pages/chats/libs/components/chat/chat.tsx
+++ b/apps/frontend/src/pages/chats/libs/components/chat/chat.tsx
@@ -14,6 +14,7 @@ import {
 	type ChatMessageItemResponseDto,
 	actions as chatMessageActions,
 } from "~/modules/chat-messages/chat-messages.js";
+import { actions as chatActions } from "~/modules/chats/chats.js";
 import { type UserAuthResponseDto } from "~/modules/users/users.js";
 
 import {
@@ -84,7 +85,8 @@ const Chat: React.FC<Properties> = ({
 
 	const handleClick = useCallback((): void => {
 		navigate(AppRoute.CHATS);
-	}, [navigate]);
+		dispatch(chatActions.leaveChat());
+	}, [navigate, dispatch]);
 
 	const chatsStyles = getValidClassNames(styles["container"], className);
 


### PR DESCRIPTION
![20240313_213016](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/110524091/6242a192-987e-45f2-a0d6-bda2ae2d838e)
