### PR TITLE
feat(frontend/shared): The "Something went wrong..." toast-message should appear instead of an empty error toast-message tm-523

### DIFF
--- a/apps/frontend/src/libs/modules/store/middlewares/handle-error.middleware.ts
+++ b/apps/frontend/src/libs/modules/store/middlewares/handle-error.middleware.ts
@@ -1,5 +1,6 @@
 import { type Middleware, isRejected } from "@reduxjs/toolkit";
 
+import { EMPTY_LENGTH } from "~/libs/constants/constants.js";
 import { ExceptionMessage } from "~/libs/enums/enums.js";
 import { notification } from "~/libs/modules/notification/notification.js";
 
@@ -10,7 +11,11 @@ const handleError: Middleware = () => {
 				const errorMessage =
 					action.error.message ?? ExceptionMessage.UNKNOWN_ERROR;
 
-				notification.error(errorMessage);
+				notification.error(
+					errorMessage.length > EMPTY_LENGTH
+						? errorMessage
+						: ExceptionMessage.SOMETHING_WENT_WRONG,
+				);
 			}
 
 			return next(action);

--- a/packages/shared/src/libs/enums/exception-message.enum.ts
+++ b/packages/shared/src/libs/enums/exception-message.enum.ts
@@ -16,7 +16,7 @@ const ExceptionMessage = {
 	NOTIFICATION_NOT_FOUND: "Notification not found.",
 	PROGRESS_NOT_FOUND: "Progress not found.",
 	SECTION_STATUS_NOT_FOUND: "Section status not found.",
-	SOMETHING_WENT_WRONG: "Something went wrong.",
+	SOMETHING_WENT_WRONG: "Something went wrong...",
 	TOKEN_EXPIRED: "Token expired.",
 	UNAUTHORIZED: "Unauthorized.",
 	UNKNOWN_ERROR: "Unknown error occurred.",

--- a/packages/shared/src/libs/enums/exception-message.enum.ts
+++ b/packages/shared/src/libs/enums/exception-message.enum.ts
@@ -16,6 +16,7 @@ const ExceptionMessage = {
 	NOTIFICATION_NOT_FOUND: "Notification not found.",
 	PROGRESS_NOT_FOUND: "Progress not found.",
 	SECTION_STATUS_NOT_FOUND: "Section status not found.",
+	SOMETHING_WENT_WRONG: "Something went wrong.",
 	TOKEN_EXPIRED: "Token expired.",
 	UNAUTHORIZED: "Unauthorized.",
 	UNKNOWN_ERROR: "Unknown error occurred.",


### PR DESCRIPTION
![20240314_084413](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/110524091/3485797c-5a3e-40b4-801d-9681e38fc80d)
