### PR TITLE
fix(shared): Typo in chats' validation message tm-513

### DIFF
--- a/packages/shared/src/modules/chat-messages/libs/enums/chat-message-validation-message.enum.ts
+++ b/packages/shared/src/modules/chat-messages/libs/enums/chat-message-validation-message.enum.ts
@@ -5,7 +5,7 @@ const ChatMessageValidationMessage = {
 	MESSAGE_ID_MINIMUM_VALUE: `Minimum messageId value – ${ChatMessageValidationRule.CHAT_ID_MINIMUM_VALUE}`,
 	MESSAGE_IDS_ARRAY_MINIMUM_LENGTH: "Array of message IDs should be not empty",
 	TEXT_MAXIMUM_LENGTH: `Maximum text length – ${ChatMessageValidationRule.TEXT_MAXIMUM_LENGTH} characters`,
-	TEXT_MINIMUM_LENGTH: `Minimum text length – ${ChatMessageValidationRule.TEXT_MINIMUM_LENGTH} characters`,
+	TEXT_MINIMUM_LENGTH: `Minimum text length – ${ChatMessageValidationRule.TEXT_MINIMUM_LENGTH} character`,
 };
 
 export { ChatMessageValidationMessage };


### PR DESCRIPTION
<img width="627" alt="image" src="https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/110524091/24cd5649-9e33-42eb-a971-ecf40cf4b4d6">
