### PR TITLE
fix(frontend): fix scrollbar appearance during transitions of comments tm-541

### DIFF
--- a/apps/frontend/src/pages/feed/libs/components/activity-comments/styles.module.css
+++ b/apps/frontend/src/pages/feed/libs/components/activity-comments/styles.module.css
@@ -7,5 +7,7 @@
 	flex-direction: column;
 	gap: 8px;
 	width: 100%;
+	max-height: 200px;
 	margin-bottom: 16px;
+	overflow-y: auto;
 }

--- a/apps/frontend/src/pages/feed/libs/components/feed-activity/feed-activity.tsx
+++ b/apps/frontend/src/pages/feed/libs/components/feed-activity/feed-activity.tsx
@@ -71,7 +71,7 @@ const FeedActivity: React.FC<Properties> = ({ activity }: Properties) => {
 					isCommentsOpen && styles["open"],
 				)}
 			>
-				<ActivityComments activityId={activity.id} />
+				{isCommentsOpen && <ActivityComments activityId={activity.id} />}
 			</div>
 		</article>
 	);

--- a/apps/frontend/src/pages/feed/libs/components/feed-activity/styles.module.css
+++ b/apps/frontend/src/pages/feed/libs/components/feed-activity/styles.module.css
@@ -79,16 +79,13 @@
 }
 
 .comments-container {
-	max-height: 0;
-	overflow: hidden;
-	overflow-y: auto;
 	pointer-events: none;
 	touch-action: none;
+	opacity: 0;
 	transition: 0.3s ease;
 }
 
 .comments-container.open {
-	max-height: 500px;
 	pointer-events: all;
 	touch-action: manipulation;
 	opacity: 1;


### PR DESCRIPTION
Fixed scrollbar appearance during transitions of comments on the Activities page

**Before:**


https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/106179834/04384aa5-1dac-416e-8412-adce65bb8953



**After:**

https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/106179834/a479097d-c305-4d99-a911-60b35af91b0d

