### PR TITLE
fix(frontend): Dates on notification elements are shifted up and overlapped by the new notification indicator [Mobile] tm-579

### DIFF
--- a/apps/frontend/src/pages/notifications/libs/components/notification-list-item/styles.module.css
+++ b/apps/frontend/src/pages/notifications/libs/components/notification-list-item/styles.module.css
@@ -98,7 +98,6 @@
 	}
 
 	.notification-date {
-		align-self: start;
 		line-height: 16px;
 	}
 


### PR DESCRIPTION
![IMAGE 2024-03-19 10:08:22](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/110524091/6acb25ea-36a3-44e1-945c-0a25829b56f6)
