### PR TITLE
fix(frontend): Courses on the "Overview" page disappear and reappear, when a new course is being added on the "Add course" pop-up window tm-610

### DIFF
--- a/apps/frontend/src/modules/user-courses/slices/user-courses.slice.ts
+++ b/apps/frontend/src/modules/user-courses/slices/user-courses.slice.ts
@@ -13,6 +13,7 @@ import {
 } from "./actions.js";
 
 type State = {
+	addCourseDataStatus: ValueOf<typeof DataStatus>;
 	commonCourses: CourseDto[];
 	commonDataStatus: ValueOf<typeof DataStatus>;
 	dataStatus: ValueOf<typeof DataStatus>;
@@ -23,6 +24,7 @@ type State = {
 };
 
 const initialState: State = {
+	addCourseDataStatus: DataStatus.IDLE,
 	commonCourses: [],
 	commonDataStatus: DataStatus.IDLE,
 	dataStatus: DataStatus.IDLE,
@@ -36,13 +38,13 @@ const { actions, name, reducer } = createSlice({
 	extraReducers(builder) {
 		builder.addCase(add.fulfilled, (state) => {
 			state.totalMyCoursesCount++;
-			state.dataStatus = DataStatus.FULFILLED;
+			state.addCourseDataStatus = DataStatus.FULFILLED;
 		});
 		builder.addCase(add.pending, (state) => {
-			state.dataStatus = DataStatus.PENDING;
+			state.addCourseDataStatus = DataStatus.PENDING;
 		});
 		builder.addCase(add.rejected, (state) => {
-			state.dataStatus = DataStatus.REJECTED;
+			state.addCourseDataStatus = DataStatus.REJECTED;
 		});
 		builder.addCase(loadMyCourses.fulfilled, (state, action) => {
 			state.myCourses = action.payload.items;


### PR DESCRIPTION
![20240319_131809](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/110524091/548d73b4-9512-4327-87e8-f846aee8d609)
