### PR TITLE
fix(frontend): The display of the extralong names on user components on the "Friends" page tm-637

### DIFF
--- a/apps/frontend/src/pages/friends/libs/components/friend/styles.module.css
+++ b/apps/frontend/src/pages/friends/libs/components/friend/styles.module.css
@@ -34,9 +34,10 @@
 
 .fullName {
 	margin: 17px 0 12px;
+	overflow: hidden;
 	font-size: var(--font-size-300);
 	font-weight: 500;
-	line-height: 1;
+	line-height: 1.1;
 	color: var(--color-text-300);
 	text-overflow: ellipsis;
 }


### PR DESCRIPTION
<img width="542" alt="image" src="https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/110524091/e92b944d-ede6-42d3-85f6-c4e67d1d05f0">
