### PR TITLE
fix(frontend): sidebar appearance wrong width after turning device with active sidebar tm-653

### DIFF
--- a/apps/frontend/src/libs/components/sidebar/styles.module.css
+++ b/apps/frontend/src/libs/components/sidebar/styles.module.css
@@ -217,6 +217,10 @@
 		transform: none;
 	}
 
+	.sidebar.open {
+		width: 100%;
+	}
+
 	.bottom-menu {
 		flex-direction: column;
 		gap: 0;


### PR DESCRIPTION
![this pwa sidebar](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/141722848/4134d801-a88f-4781-8a78-00dfb3fd49a1)
