### PR TITLE
fix(frontend): search with pagination on the overview and friends profile pages tm-683

### DIFF
--- a/apps/frontend/src/pages/overview/overview.tsx
+++ b/apps/frontend/src/pages/overview/overview.tsx
@@ -95,6 +95,7 @@ const Overview: React.FC = () => {
 									currentPage={page}
 									pages={pages}
 									pagesCount={pagesCount}
+									searchQuery={searchQuery}
 								/>
 							</div>
 						) : (

--- a/apps/frontend/src/pages/user/user.tsx
+++ b/apps/frontend/src/pages/user/user.tsx
@@ -18,6 +18,7 @@ import {
 	AppTitle,
 	DataStatus,
 	PaginationValue,
+	QueryParameterName,
 } from "~/libs/enums/enums.js";
 import {
 	useAppDispatch,
@@ -28,6 +29,7 @@ import {
 	useNavigate,
 	usePagination,
 	useParams,
+	useSearchParams,
 } from "~/libs/hooks/hooks.js";
 import { actions as friendsActions } from "~/modules/friends/friends.js";
 import { actions as userCoursesActions } from "~/modules/user-courses/user-courses.js";
@@ -64,6 +66,8 @@ const User: React.FC = () => {
 			totalCount: state.userCourses.totalUserCoursesCount,
 		};
 	});
+	const [queryParameters] = useSearchParams();
+	const searchQuery = queryParameters.get(QueryParameterName.SEARCH);
 
 	const { page, pages, pagesCount } = usePagination({
 		pageSize: PaginationValue.DEFAULT_COUNT,
@@ -110,11 +114,11 @@ const User: React.FC = () => {
 			userCoursesActions.loadUserCourses({
 				count: PaginationValue.DEFAULT_COUNT,
 				page,
-				search: "",
+				search: searchQuery ?? "",
 				userId,
 			}),
 		);
-	}, [dispatch, userId, page]);
+	}, [dispatch, userId, page, searchQuery]);
 
 	const hasUser = Boolean(profileUser);
 	const hasCommonCourses = commonCourses.length > EMPTY_LENGTH;

--- a/apps/frontend/src/pages/user/user.tsx
+++ b/apps/frontend/src/pages/user/user.tsx
@@ -183,6 +183,7 @@ const User: React.FC = () => {
 									currentPage={page}
 									pages={pages}
 									pagesCount={pagesCount}
+									searchQuery={searchQuery}
 								/>
 							</div>
 						) : (


### PR DESCRIPTION
- The search is not reset when changing the page.
- Search is available and works with pagination on a friend's profile page.