### PR TITLE
fix(frontend): labels on the buttons of the courses components tm-684

### DIFF
--- a/apps/frontend/src/libs/components/courses/styles.module.css
+++ b/apps/frontend/src/libs/components/courses/styles.module.css
@@ -15,13 +15,13 @@
 	}
 }
 
-@media screen and (--medium-screen) {
+@media screen and (width <= 875) {
 	.list {
 		grid-template-columns: repeat(2, 1fr);
 	}
 }
 
-@media screen and (--small-screen) {
+@media screen and (width <= 580) {
 	.list {
 		grid-template-columns: 1fr;
 	}


### PR DESCRIPTION
- Modal
![course-list-mobile-light](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/c98ceeda-111c-4684-88c0-6f1fc76d5e37)

- Overview and friends' page
![course-list-ov-light](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/da0a9c93-3608-4a16-8af5-947c47d58efe)


Explanation:
The list of courses can not be adjusted to those standard breakpoints that we have, if you look at the deployment, not only inside the modal window but also on the main page at some width course cards are extremely small. I still insist on choosing other breakpoints for this list, so that it would look normal on any devices, I consulted with QA and they approved this option.
From what is currently at the deployment:
![image](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/71721870/ec32efff-7df2-42a8-83c3-aa4123cc7e52)
