### PR TITLE
fix(backend): The premium state of the user is disappeared after liking the activity tm-701

### DIFF
--- a/apps/backend/src/modules/activities/activity.repository.ts
+++ b/apps/backend/src/modules/activities/activity.repository.ts
@@ -285,7 +285,7 @@ class ActivityRepository implements Repository<ActivityEntity> {
 				this.getUserLikesCountQuery(userId),
 			)
 			.withGraphJoined(
-				`${RelationName.USER}.[${RelationName.USER_DETAILS}.${RelationName.AVATAR_FILE}, ${RelationName.GROUPS}.${RelationName.PERMISSIONS}]`,
+				`${RelationName.USER}.[${RelationName.USER_DETAILS}.[${RelationName.AVATAR_FILE},${RelationName.SUBSCRIPTION}], ${RelationName.GROUPS}.${RelationName.PERMISSIONS}]`,
 			)
 			.castTo<(ActivityModel & ActivityCounts) | undefined>()
 			.execute();


### PR DESCRIPTION
![20240322_221323](https://github.com/BinaryStudioAcademy/bsa-winter-2023-2024-trackmates/assets/110524091/d96d64ef-f219-4a0d-aea2-6a111aa96354)
