### PR TITLE
fix(frontend): z-index for vendor and link to subdcription pop-up tm-622

### DIFF
--- a/apps/frontend/src/libs/components/course/libs/component/course-card/styles.module.css
+++ b/apps/frontend/src/libs/components/course/libs/component/course-card/styles.module.css
@@ -22,7 +22,7 @@
 	position: absolute;
 	top: -1px;
 	right: 25px;
-	z-index: var(--z-index-high);
+	z-index: var(--z-index-low);
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/apps/frontend/src/pages/user/user.tsx
+++ b/apps/frontend/src/pages/user/user.tsx
@@ -199,7 +199,7 @@ const User: React.FC = () => {
 					{!hasSubscription && (
 						<p className={styles["courses-subtitle"]}>
 							Want to compare your progress with your friend? Then{" "}
-							<Link className={styles["link"]} to={AppRoute.PROFILE}>
+							<Link className={styles["link"]} to={AppRoute.SUBSCRIPTION}>
 								subscribe
 							</Link>
 							!


### PR DESCRIPTION
- Vendor icons do not overlap the open sidebar in the mobile or tablet version.
- The subscription link leads directly to the pop-up